### PR TITLE
Add OPTIONS route for /v1/chat/completions endpoint

### DIFF
--- a/flight.py
+++ b/flight.py
@@ -33,8 +33,14 @@ api_key = env.get('api_key',None)
 if api_key is not None:
   api_key = digest(api_key)
 
-@app.route('/v1/chat/completions', methods=['POST'])
+@app.route('/v1/chat/completions', methods=['POST', 'OPTIONS'])
 async def completions():
+    if request.method == 'OPTIONS':
+      return await make_response('', 200, {
+        'Access-Control-Allow-Origin': "*",
+        "Access-Control-Allow-Methods": "*",
+        "Access-Control-Allow-Headers": "*",
+      })
     token = request.headers.get('Authorization').split(' ')[-1]
     if api_key is not None and (not hash_compare(api_key, digest(token))):
       return {'code': 403, 'message': 'Invalid API Key'},403

--- a/utils.py
+++ b/utils.py
@@ -52,7 +52,7 @@ def to_openai_title_data(title: str):
     "id": id,
     "object": "chat.completion",
     "created": str(int(time.time())),
-    "model": "gpt4",
+    "model": "gpt-4",
     "choices": [
         {
             "index": 0,


### PR DESCRIPTION
I have found that API is no longer working for UI apps like NextChat or BetterChatGPT. Direct POST request was still working, leaving me wondering.

After capturing some traffic with WireShark, I found out that now they're doing OPTIONS request before making the POST request

This PR fixes that

Before:
![image](https://github.com/xingty/bingai2openai/assets/28294714/5760d9d1-9e6b-479e-a262-22f23ffb5625)
After:
![image](https://github.com/xingty/bingai2openai/assets/28294714/2e97166f-0d7e-42c0-bb68-ee8550029e97)
